### PR TITLE
Replace objects on followup API reads

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -136,6 +136,7 @@ export const readEndpoint = (endpoint, {
   onError: onError = noop,
   options = {
     indexLinks: undefined,
+    clearTypes: []
   }
 } = {}) => {
   if (onSuccess !== noop || onError !== noop) {

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -342,7 +342,7 @@ export const reducer = handleActions({
         : [payload.data]
     ).concat(payload.included || []);
 
-    const newState = updateOrInsertResourcesIntoState(state, resources);
+    const newState = updateOrInsertResourcesIntoState(state, resources, payload.options);
     const finalState = addLinksToState(newState, payload.links, payload.options);
 
     return imm(finalState)

--- a/src/state-mutation.js
+++ b/src/state-mutation.js
@@ -189,8 +189,9 @@ export const removeResourceFromState = (state, resource) => {
   }, imm(state).del(path));
 };
 
-export const updateOrInsertResourcesIntoState = (state, resources, clearTypes = []) => {
+export const updateOrInsertResourcesIntoState = (state, resources, payloadOptions = {}) => {
   let newState = state;
+  const clearTypes = payloadOptions.clearTypes || [];
 
   clearTypes.forEach((type) => {
     newState = imm.del(newState, type);

--- a/src/state-mutation.js
+++ b/src/state-mutation.js
@@ -189,9 +189,15 @@ export const removeResourceFromState = (state, resource) => {
   }, imm(state).del(path));
 };
 
-export const updateOrInsertResourcesIntoState = (state, resources) => (
-  resources.reduce(updateOrInsertResource, state)
-);
+export const updateOrInsertResourcesIntoState = (state, resources, clearTypes = []) => {
+  let newState = state;
+
+  clearTypes.forEach((type) => {
+    newState = imm.del(newState, type);
+  });
+
+  return resources.reduce(updateOrInsertResource, newState);
+};
 
 export const setIsInvalidatingForExistingResource = (state, { type, id }, value = null) => {
   const idx = state[type].data.findIndex(e => e.id === id && e.type === type);

--- a/test/clear-types.js
+++ b/test/clear-types.js
@@ -1,0 +1,26 @@
+import expect from 'expect';
+import { createAction } from 'redux-actions';
+
+import usersPayloadInitial from './payloads/users_primary.json';
+import usersPayloadFollowup from './payloads/users_secondary.json';
+
+import { reducer } from '../src/jsonapi';
+
+const apiRead = createAction('API_READ');
+
+describe('[State mutation] Testing ClearType', () => {
+  it('should append user resources to state on subsequent api reads', () => {
+    const state = {};
+
+    const updatedState = reducer(state, apiRead(usersPayloadInitial));
+    expect(updatedState.users.data.length).toEqual(usersPayloadInitial.data.length);
+    expect(updatedState.users.data[0].attributes.name).toEqual("John Doe");
+
+    const tertiaryState = reducer(updatedState, apiRead(usersPayloadFollowup));
+    expect(tertiaryState.users.data.length).toEqual(4);
+    expect(tertiaryState.users.data[2].attributes.github).toEqual("chrisjowen");
+  });
+
+  it('should replace user resources in state on subsequent api reads when clearType is set', () => {
+  });
+});

--- a/test/clear-types.js
+++ b/test/clear-types.js
@@ -12,15 +12,27 @@ describe('[State mutation] Testing ClearType', () => {
   it('should append user resources to state on subsequent api reads', () => {
     const state = {};
 
-    const updatedState = reducer(state, apiRead(usersPayloadInitial));
-    expect(updatedState.users.data.length).toEqual(usersPayloadInitial.data.length);
-    expect(updatedState.users.data[0].attributes.name).toEqual("John Doe");
+    const secondaryState = reducer(state, apiRead(usersPayloadInitial));
+    expect(secondaryState.users.data.length).toEqual(usersPayloadInitial.data.length);
+    expect(secondaryState.users.data[0].attributes.name).toEqual('John Doe');
 
-    const tertiaryState = reducer(updatedState, apiRead(usersPayloadFollowup));
+    const tertiaryState = reducer(secondaryState, apiRead(usersPayloadFollowup));
     expect(tertiaryState.users.data.length).toEqual(4);
-    expect(tertiaryState.users.data[2].attributes.github).toEqual("chrisjowen");
+    expect(tertiaryState.users.data[2].attributes.github).toEqual('chrisjowen');
   });
 
   it('should replace user resources in state on subsequent api reads when clearType is set', () => {
+    const state = {};
+
+    const secondaryState = reducer(state, apiRead(usersPayloadInitial));
+    expect(secondaryState.users.data.length).toEqual(usersPayloadInitial.data.length);
+    expect(secondaryState.users.data[0].attributes.name).toEqual('John Doe');
+
+    const replacingPayload = usersPayloadFollowup;
+    replacingPayload.options = { clearTypes: ['users'] };
+
+    const tertiaryState = reducer(secondaryState, apiRead(replacingPayload));
+    expect(tertiaryState.users.data.length).toEqual(2);
+    expect(tertiaryState.users.data[0].attributes.github).toEqual('chrisjowen');
   });
 });

--- a/test/payloads/users_primary.json
+++ b/test/payloads/users_primary.json
@@ -1,0 +1,18 @@
+{
+    "data": [
+        {
+        "type": "users",
+        "id": "1",
+        "attributes": {
+            "name": "John Doe"
+        }
+        },
+        {
+        "type": "users",
+        "id": "2",
+        "attributes": {
+            "name": "Emily Jane"
+        }
+        }
+    ]
+}

--- a/test/payloads/users_secondary.json
+++ b/test/payloads/users_secondary.json
@@ -2,7 +2,7 @@
     "data": [
         {
         "type": "users",
-        "id": "1",
+        "id": "3",
         "attributes": {
             "name": "Chris Jowen",
             "github": "chrisjowen"
@@ -10,7 +10,7 @@
         },
         {
         "type": "users",
-        "id": "2",
+        "id": "4",
         "attributes": {
             "name": "Chris Manson",
             "github": "mansona"

--- a/test/payloads/users_secondary.json
+++ b/test/payloads/users_secondary.json
@@ -1,0 +1,20 @@
+{
+    "data": [
+        {
+        "type": "users",
+        "id": "1",
+        "attributes": {
+            "name": "Chris Jowen",
+            "github": "chrisjowen"
+        }
+        },
+        {
+        "type": "users",
+        "id": "2",
+        "attributes": {
+            "name": "Chris Manson",
+            "github": "mansona"
+        }
+        }
+    ]
+}


### PR DESCRIPTION
Extending on the work @mansona had done to implement a quick version of the issue discussed at https://github.com/dixieio/redux-json-api/issues/24

See PR https://github.com/dixieio/redux-json-api/pull/108 for his thinking.

Added tests to check that developers can still use the default append behaviour but also get clobbering behaviour when using the `clearType` option.