### PR TITLE
Add the ability to set the meta attribute on update/create resource

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -47,9 +47,9 @@ export const createResource = (resource) => {
     const options = {
       ... axiosConfig,
       method: 'POST',
-      data: JSON.stringify({
+      data: {
         data: resource
-      })
+      }
     };
 
     return new Promise((resolve, reject) => {

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -39,17 +39,23 @@ const apiWillDelete = createAction(API_WILL_DELETE);
 const apiDeleted = createAction(API_DELETED);
 const apiDeleteFailed = createAction(API_DELETE_FAILED);
 
-export const createResource = (resource) => {
+export const createResource = (resource, meta) => {
   return (dispatch, getState) => {
     dispatch(apiWillCreate(resource));
 
     const { axiosConfig } = getState().api.endpoint;
+
+    const data = {
+      data: resource
+    };
+    if (meta) {
+      data.meta = meta;
+    }
+
     const options = {
       ... axiosConfig,
       method: 'POST',
-      data: {
-        data: resource
-      }
+      data
     };
 
     return new Promise((resolve, reject) => {
@@ -113,7 +119,7 @@ export const readEndpoint = (endpoint, {
   };
 };
 
-export const updateResource = (resource) => {
+export const updateResource = (resource, meta) => {
   return (dispatch, getState) => {
     dispatch(apiWillUpdate(resource));
 
@@ -127,6 +133,10 @@ export const updateResource = (resource) => {
         data: resource
       }
     };
+
+    if (meta) {
+      options.data.meta = meta;
+    }
 
     return new Promise((resolve, reject) => {
       apiRequest(endpoint, options)

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -447,6 +447,22 @@ describe('Creation of new resources', () => {
 
       expect(apiRequest).toHaveBeenCalledWith(taskWithoutRelationship.data.type, expectedOptions);
     });
+
+    it('should create a request with metadata when provided', () => {
+      const apiRequest = expect.spyOn(utils, 'apiRequest').andReturn(Promise.resolve());
+      const meta = { test: '123' };
+      const thunk = createResource(taskWithoutRelationship.data, meta);
+
+      const expectedOptions = {
+        ...state.endpoint.axiosConfig,
+        method: 'POST',
+        data: { ...taskWithoutRelationship, meta }
+      };
+
+      thunk(() => null, () => ({ api: state }));
+
+      expect(apiRequest).toHaveBeenCalledWith(taskWithoutRelationship.data.type, expectedOptions);
+    });
   });
 });
 
@@ -542,6 +558,23 @@ describe('Updating resources', () => {
         ...state.endpoint.axiosConfig,
         method: 'PATCH',
         data: taskWithoutRelationship
+      };
+
+      thunk(() => null, () => ({ api: state }));
+
+      expect(apiRequest).toHaveBeenCalledWith(expectedEndpoint, expectedOptions);
+    });
+
+    it('should create a request with metadata when provided', () => {
+      const apiRequest = expect.spyOn(utils, 'apiRequest').andReturn(Promise.resolve());
+      const meta = { test: '123' };
+      const thunk = updateResource(taskWithoutRelationship.data, meta);
+
+      const expectedEndpoint = `${taskWithoutRelationship.data.type}/${taskWithoutRelationship.data.id}`;
+      const expectedOptions = {
+        ...state.endpoint.axiosConfig,
+        method: 'PATCH',
+        data: { ...taskWithoutRelationship, meta }
       };
 
       thunk(() => null, () => ({ api: state }));


### PR DESCRIPTION
This simply exposes a way to include metadata on the update/create requests. This is something that is supported by the spec and I am using to support some custom functionality (in my case, perform multiple creates/updates in one request in a single db transaction).

I didn't create a test for this as there are no existing tests for the action creators in the test suite and I wasn't sure what the preferred mocking/stubbing method was.