### PR TITLE
Handle resource.relationships undefined in updateOrInsertResource

### DIFF
--- a/src/state-mutation.js
+++ b/src/state-mutation.js
@@ -122,7 +122,7 @@ export const updateOrInsertResource = (state, resource) => {
 
     const relationships = {};
     for (const relationship in resources[idx].relationships) {
-      if (!resource.relationships || !resource.relationships[relationship] || !resource.relationships[relationship].data) {
+      if (!hasOwnProperties(resource, ['relationships', relationship, 'data'])) {
         relationships[relationship] = resources[idx].relationships[relationship];
       }
     }

--- a/src/state-mutation.js
+++ b/src/state-mutation.js
@@ -121,12 +121,16 @@ export const updateOrInsertResource = (state, resource) => {
     const idx = resources.findIndex(item => item.id === resource.id);
 
     const relationships = {};
-    for (const relationship in resource.relationships) {
-      if (!resource.relationships[relationship].data) {
+    for (const relationship in resources[idx].relationships) {
+      if (!resource.relationships || !resource.relationships[relationship] || !resource.relationships[relationship].data) {
         relationships[relationship] = resources[idx].relationships[relationship];
       }
     }
-    Object.assign(resource.relationships, relationships);
+    if (!resource.hasOwnProperty('relationships')) {
+      Object.assign(resource, { relationships });
+    } else {
+      Object.assign(resource.relationships, relationships);
+    }
 
     if (!equal(resources[idx], resource)) {
       newState = imm.set(newState, updatePath.concat(idx), resource);

--- a/test/state-mutation.js
+++ b/test/state-mutation.js
@@ -156,6 +156,45 @@ describe('[State mutation] Insertion of resources', () => {
 
     expect(updatedState.topics.data.length).toEqual(topics.data.length);
   });
+
+  it('should work when resource exists and data has no relationships', () => {
+    const payload = {
+      data: [
+        {
+          type: 'users',
+          id: '1',
+          attributes: {
+            some: 'attribute',
+          },
+        }
+      ],
+    };
+    expect(() => updateOrInsertResourcesIntoState(
+      state, payload.data
+    )).toNotThrow();
+  });
+
+  it('should persists existing relationships when response has none', () => {
+    const payload = {
+      data: [
+        {
+          type: 'users',
+          id: '1',
+          attributes: {
+            some: 'attribute',
+          },
+        }
+      ],
+    };
+
+    const updatedState = updateOrInsertResourcesIntoState(
+      state, payload.data
+    );
+
+    expect(updatedState.users.data[0].relationships).toEqual(
+      state.users.data[0].relationships
+    );
+  });
 });
 
 describe('[State mutation] Insertion of empty resources type', () => {


### PR DESCRIPTION
When an endpoint returns data without a relationships attribute, the following code crashes : 

```
    const relationships = {};
    for (const relationship in resource.relationships) {
      if (!resource.relationships[relationship].data) {
        relationships[relationship] = resources[idx].relationships[relationship];
      }
    }
    Object.assign(resource.relationships, relationships);
    ^^^^^^^^^^^
    if (!equal(resources[idx], resource)) {
      newState = imm.set(newState, updatePath.concat(idx), resource);
    }
```
Because `Object` can't assign to `undefined`.

The [json api](http://jsonapi.org/format/#document-resource-objects) spec does say that the `relationships` MAY be present, but necessarly : 

```
In addition, a resource object MAY contain any of these top-level members:

attributes: an attributes object representing some of the resource’s data.
relationships: a relationships object describing relationships between the resource and other JSON API resources.
links: a links object containing links related to the resource.
meta: a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship.
```

To fix this, we simply assign an empty object when no relationships is present.